### PR TITLE
Update requirements

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,6 +8,8 @@ jobs:
     matrix:
       osx_c_compilerclangtarget_platformosx-64:
         CONFIG: osx_c_compilerclangtarget_platformosx-64
+      osx_c_compilertoolchain_ctarget_platformosx-64:
+        CONFIG: osx_c_compilertoolchain_ctarget_platformosx-64
 
   steps:
   # TODO: Fast finish on azure pipelines?

--- a/.ci_support/osx_c_compilertoolchain_ctarget_platformosx-64.yaml
+++ b/.ci_support/osx_c_compilertoolchain_ctarget_platformosx-64.yaml
@@ -1,17 +1,17 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 build_number_decrement:
-- '0'
+- '1000'
 c_compiler:
-- clang
+- toolchain_c
 channel_sources:
-- conda-forge/label/gcc7,defaults
+- conda-forge,defaults
 channel_targets:
-- conda-forge gcc7
+- conda-forge main
 cran_mirror:
 - https://cran.r-project.org
 cxx_compiler:
-- clangxx
+- toolchain_cxx
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/win_c_compilervs2015target_platformwin-64vc14.yaml
+++ b/.ci_support/win_c_compilervs2015target_platformwin-64vc14.yaml
@@ -6,10 +6,6 @@ channel_targets:
 - conda-forge main
 cran_mirror:
 - https://cran.r-project.org
-m2w64_c_compiler:
-- m2w64-toolchain
-m2w64_cxx_compiler:
-- m2w64-toolchain
 pin_run_as_build:
   r-base:
     max_pin: x.x.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ osx_image: xcode9.4
 env:
   matrix:
     - CONFIG=osx_c_compilerclangtarget_platformosx-64
+    - CONFIG=osx_c_compilertoolchain_ctarget_platformosx-64
 
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,18 +15,16 @@ source:
 build:
   merge_build_host: True  # [win]
   skip: True  # [osx and c_compiler == "toolchain_c" or win and vc<14]
-  number: 1000
+  number: 1001
   rpaths:
     - lib/R/lib/
     - lib/
 
 requirements:
   build:
-    - {{ compiler('c') }}        # [linux]
-    - {{ compiler('cxx') }}      # [linux]
-    - llvm-openmp                # [osx]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ compiler('c') }}        # [linux or osx and c_compiler == "toolchain_c"]
+    - {{ compiler('cxx') }}      # [linux or osx and c_compiler == "toolchain_c"]
+    - {{native}}toolchain        # [win]
     - {{posix}}filesystem        # [win]
     - {{posix}}make
     - {{posix}}sed               # [win]
@@ -37,6 +35,8 @@ requirements:
   run:
     - r-base
     - {{native}}gcc-libs         # [win]
+    - libcxx                     # [osx and c_compiler == "clang"]
+    - llvm-openmp                # [osx and c_compiler == "clang"]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   merge_build_host: True  # [win]
-  skip: True  # [osx and c_compiler == "toolchain_c" or win and vc<14]
+  skip: True  # [win and vc<14]
   number: 1001
   rpaths:
     - lib/R/lib/


### PR DESCRIPTION
Only the the target 'osx and c_compiler == "clang"' is special. See also conda-forge/r-openimager-feedstock#1

Fixes the two osx gcc7 build warnings:
* `WARNING (r-hypergea,lib/R/library/hypergea/libs/hypergea.so): Needed DSO lib/libc++.1.dylib found in ['libcxx']`
* `WARNING (r-hypergea,lib/R/library/hypergea/libs/hypergea.so): .. but ['llvm-openmp'] not in reqs/run, (i.e. it is overlinking) (likely) or a missing dependency (less likely)`

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
